### PR TITLE
Added a link to mongo doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ Usage
     TestCollection.findAndModify({
       query: {name: "Robin"},
       sort: {age: -1},
+      skip: 2,  // available only client side
       remove: true
     });
 
+See mongo documentation for arguments details:
+http://docs.mongodb.org/manual/reference/method/db.collection.findAndModify/
 
 License
 ------- 


### PR DESCRIPTION
A link is handy if someone  doesn't know the format options by heart.

Also it can help to mention that 'skip' can be used client side or include it in an example.
